### PR TITLE
Syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
     include PollBooth
 
     cache 10.seconds do
-      Hash[Member.all.map { |member| [member.id, member.age] }
+      Hash[Member.all.map { |member| [member.id, member.age] }]
     end
   end
 ```


### PR DESCRIPTION
I'm not very familiar with Ruby but I think this fixes a syntax error in README.md
